### PR TITLE
Clarify Ignite UI Grid Lite as Web Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Ignite UI Grid Lite
+# Ignite UI Grid Lite for Web Components
 [![Node.js CI](https://github.com/IgniteUI/igniteui-grid-lite/actions/workflows/node.js.yml/badge.svg)](https://github.com/IgniteUI/igniteui-grid-lite/actions/workflows/node.js.yml)
 [![Coverage Status](https://coveralls.io/repos/github/IgniteUI/igniteui-grid-lite/badge.svg?branch=master)](https://coveralls.io/github/IgniteUI/igniteui-grid-lite?branch=master)
 [![npm version](https://badge.fury.io/js/igniteui-grid-lite.svg)](https://badge.fury.io/js/igniteui-grid-lite)
 
-Ignite UI Grid Lite is a high-performance, lightweight data grid built as a web component using [Lit](https://lit.dev/). It provides essential grid functionality with a small footprint, making it perfect for applications that need fast, efficient data visualization without the overhead of a full-featured grid.
+Ignite UI Grid Lite for Web Components is a high-performance, lightweight data grid built as a web component using [Lit](https://lit.dev/). It provides essential grid functionality with a small footprint, making it perfect for applications that need fast, efficient data visualization without the overhead of a full-featured grid.
 
 ## Table of Contents
 - [Features](#features)
@@ -13,14 +13,14 @@ Ignite UI Grid Lite is a high-performance, lightweight data grid built as a web 
 - [Building the Library](#building-the-library)
 - [Running Tests](#running-tests)
 - [Documentation](#documentation)
-- [Ignite UI Grid Lite vs. Ignite UI for Angular](#ignite-ui-grid-lite-vs-ignite-ui-for-angular)
+- [Ignite UI Open-Source vs. Premium for Web Comonents](https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/general-open-source-vs-premium)
 - [Contributing](#contributing)
 - [Support](#support)
 - [License](#license)
 
 ## Features
 
-Ignite UI Grid Lite provides core data grid capabilities with an emphasis on performance and simplicity:
+Ignite UI Grid Lite for Web Components provides core data grid capabilities with an emphasis on performance and simplicity:
 
 - **High Performance Row Virtualization** - Handles large datasets efficiently with built-in virtual scrolling
 - **Column Filtering** - Built-in column filtering capabilities
@@ -35,7 +35,7 @@ Ignite UI Grid Lite provides core data grid capabilities with an emphasis on per
 
 ## Browser Support
 
-Ignite UI Grid Lite supports all modern browsers:
+Ignite UI Grid Lite for Web Components supports all modern browsers:
 
 | ![chrome] | ![firefox] | ![edge] | ![safari] | ![opera] |
 |:---:|:---:|:---:|:---:|:---:|
@@ -144,11 +144,11 @@ Documentation will be available in the build output.
 - <a href="https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/grid-lite/overview">Grid Lite Documentation</a>
 - [Web Components Guide](https://lit.dev/)
 
-## Ignite UI Grid Lite vs. Ignite UI for Angular
+## Ignite UI Grid Lite vs. Ignite UI for Web Components
 
 Ignite UI Grid Lite is designed as a lightweight, open-source alternative to the full-featured <a href="https://www.infragistics.com/products/ignite-ui-web-components/web-components/components/grids/data-grid">Ignite UI for Web Components Data Grid</a>, while allowing for an easy swap with the full-featured grid, if application needs require it.
 
-### Ignite UI Grid Lite (Open Source - MIT)
+### Ignite UI Grid Lite for Web Components (Open Source - MIT)
 
 **Best for:**
 - Applications requiring basic grid functionality


### PR DESCRIPTION
Updated README to clarify that Ignite UI Grid Lite is specifically for Web Components and made minor adjustments for consistency.