### PR TITLE
Comment out NODE_AUTH_TOKEN in npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -42,5 +42,5 @@ jobs:
       - name: Publish the package
         run: npm publish --tag ${NPM_TAG}
         working-directory: dist
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+     #   env:
+     #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
Comment out the NODE_AUTH_TOKEN environment variable for npm publish.