### PR TITLE
ci(npm-publish): pin npm@11 due to sigstore packaging issue

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,9 +22,9 @@ jobs:
           cache: 'npm'
           registry-url: https://registry.npmjs.org/
 
-      # Ensure npm 11.5.1 or later is installed in order to npm OIDC to work
-      - name: Update npm
-        run: npm install -g npm@latest
+      # Pin 11 for https://github.com/npm/cli/issues/9722
+      - name: Pin npm
+        run: npm install -g npm@11
 
       - run: npm ci
       - run: npm run build


### PR DESCRIPTION
Latest Node 24-s ship with npm versions that satisfy the requirements for OIDC now:
```
  node: v24.18.0
  npm: 11.16.0
```

However the Update step picked up 12.0.0 stable presumably and failed:
```
Run npm publish --tag ${NPM_TAG}
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'sigstore'
```
https://github.com/IgniteUI/igniteui-grid-lite/actions/runs/29032081040/job/86167229872#step:11:11

That seems to be related to https://github.com/npm/cli/issues/9722

While the update step should be unnecessary atm, leaving in as a safety net, just in case a node 24 release picks it up before the above issue is fixed.